### PR TITLE
Remove Unnecessary deltaTime Specification for BrainBase and EarlyUpdateBrain

### DIFF
--- a/Packages/com.utj.charactercontroller/Runtime/BatchProcessor/GameControllerManager.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/BatchProcessor/GameControllerManager.cs
@@ -33,16 +33,12 @@ namespace Unity.TinyCharacterController.Core
                 return;
 
             var gameController = GetInstance(timing);
+
+            if (system is IEarlyUpdate update)
+                gameController._updates.Add(update);
             
-            switch (system)
-            {
-                case IEarlyUpdate update:
-                    gameController._updates.Add(update);
-                    break;
-                case IPostUpdate lateUpdate:
-                    gameController._lateUpdates.Add(lateUpdate);
-                    break;
-            }
+            if (system is IPostUpdate lateUpdate) 
+                gameController._lateUpdates.Add(lateUpdate);
         }
         
         /// <summary>

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Brain/CharacterBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Brain/CharacterBrain.cs
@@ -132,7 +132,7 @@ namespace Unity.TinyCharacterController.Brain
 
         private void Update()
         {
-            UpdateBrain(Time.deltaTime);
+            UpdateBrain();
         }
 
 

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Brain/NavmeshBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Brain/NavmeshBrain.cs
@@ -57,7 +57,7 @@ namespace Unity.TinyCharacterController.Brain
 
         private void Update()
         {
-            UpdateBrain(Time.deltaTime);
+            UpdateBrain();
         }
 
         protected override void ApplyPosition(in Vector3 totalVelocity, float deltaTime)

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Brain/RigidbodyBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Brain/RigidbodyBrain.cs
@@ -162,7 +162,7 @@ namespace Unity.TinyCharacterController.Brain
 
         private void FixedUpdate()
         {
-            UpdateBrain(Time.fixedDeltaTime);
+            UpdateBrain();
         }
 
         private void Update()

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Brain/TransformBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Brain/TransformBrain.cs
@@ -37,7 +37,7 @@ namespace Unity.TinyCharacterController.Brain
 
         private void Update()
         {
-            UpdateBrain(Time.deltaTime);
+            UpdateBrain();
         }
 
         public override UpdateTiming Timing => UpdateTiming.Update;

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Core/BrainBase.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Core/BrainBase.cs
@@ -161,11 +161,13 @@ namespace Unity.TinyCharacterController.Core
         /// <summary>
         /// Update information in Brain.<br/>
         /// </summary>
-        /// <param name="deltaTime">delta time</param>
-        protected void UpdateBrain(float deltaTime)
+        protected void UpdateBrain()
         {
             if (HasCameraCheck() == false)
                 return;
+
+            // If executed at the timing of FixedUpdate, deltaTime returns the value of FixedUpdate.
+            var deltaTime = Time.deltaTime;
 
             // Update coordinates
             _updateComponentManager.Process(deltaTime);

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyFixedUpdateBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyFixedUpdateBrain.cs
@@ -9,9 +9,6 @@ namespace Unity.TinyCharacterController.Core
     [AddComponentMenu("")]
     public class EarlyFixedUpdateBrain : EarlyUpdateBrainBase
     {
-        private void FixedUpdate()
-        {
-            OnUpdate(Time.fixedDeltaTime);
-        }
+        private void FixedUpdate() => OnUpdate();
     }
 }

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyUpdateBrain.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyUpdateBrain.cs
@@ -11,6 +11,6 @@ namespace Unity.TinyCharacterController.Core
     [AddComponentMenu("")]
     public class EarlyUpdateBrain : EarlyUpdateBrainBase
     {
-        private void Update() => OnUpdate(Time.deltaTime);
+        private void Update() => OnUpdate();
     }
 }

--- a/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyUpdateBrainBase.cs
+++ b/Packages/com.utj.charactercontroller/Runtime/Components/Core/EarlyUpdateBrainBase.cs
@@ -15,11 +15,14 @@ namespace Unity.TinyCharacterController.Core
             _updates.Sort((a,b) => a.Order - b.Order);
         }
 
-        protected void OnUpdate(float deltaTime)
+        protected void OnUpdate()
         {
+            // If executed at the timing of FixedUpdate, deltaTime returns the value of FixedUpdate.
+            var deltaTime = Time.deltaTime;
+            
             foreach (var update in _updates)
             {
-                update.OnUpdate(Time.deltaTime);
+                update.OnUpdate(deltaTime);
             }
         }
     }

--- a/Packages/com.utj.charactercontroller/Tests/Scenes/BrainUpdateTest.unity
+++ b/Packages/com.utj.charactercontroller/Tests/Scenes/BrainUpdateTest.unity
@@ -1,0 +1,590 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &625583716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625583719}
+  - component: {fileID: 625583718}
+  - component: {fileID: 625583717}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &625583717
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625583716}
+  m_Enabled: 1
+--- !u!20 &625583718
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625583716}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &625583719
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625583716}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &984588221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 984588223}
+  - component: {fileID: 984588222}
+  - component: {fileID: 984588224}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &984588222
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984588221}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &984588223
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984588221}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &984588224
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984588221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!1 &1981571403
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1981571410}
+  - component: {fileID: 1981571409}
+  - component: {fileID: 1981571408}
+  - component: {fileID: 1981571407}
+  - component: {fileID: 1981571406}
+  - component: {fileID: 1981571405}
+  - component: {fileID: 1981571404}
+  m_Layer: 0
+  m_Name: RigidbodyBrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1981571404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a438fe455bc974e68babcfff4ef6d954, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _gravityScale: 1
+  _onLanding:
+    m_PersistentCalls:
+      m_Calls: []
+  _onLeave:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1981571405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54a396cd71dde4e269ccacb449e74791, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GroundHeight: 0
+  _toleranceHeight: 0
+--- !u!114 &1981571406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4177e54639ce44b5fb3c2e49045a9479, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _freezeAxis:
+    x: 0
+    y: 0
+    z: 0
+  _skinWidth: 0.08
+  _stepHeight: 0.2
+--- !u!136 &1981571407
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 1.4
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.7, z: 0}
+--- !u!114 &1981571408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21501635e762343f1b16e2d5c7aed266, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _environmentLayer:
+    serializedVersion: 2
+    m_Bits: 1
+  _mass: 1
+  _height: 1.4
+  _radius: 0.5
+--- !u!54 &1981571409
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 5
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 0
+--- !u!4 &1981571410
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981571403}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2144716354
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2144716358}
+  - component: {fileID: 2144716357}
+  - component: {fileID: 2144716356}
+  - component: {fileID: 2144716355}
+  m_Layer: 0
+  m_Name: CharacterBrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &2144716355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2144716354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bc4954e2495401681e4dc93f6a28af6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _freezeAxis:
+    x: 0
+    y: 0
+    z: 0
+  Pushable: 1
+  _detectCollisions: 1
+--- !u!114 &2144716356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2144716354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21501635e762343f1b16e2d5c7aed266, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _environmentLayer:
+    serializedVersion: 2
+    m_Bits: 1
+  _mass: 1
+  _height: 1.4
+  _radius: 0.5
+--- !u!143 &2144716357
+CharacterController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2144716354}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Height: 1.24
+  m_Radius: 0.5
+  m_SlopeLimit: 45
+  m_StepOffset: 0.3
+  m_SkinWidth: 0.08
+  m_MinMoveDistance: 0.001
+  m_Center: {x: 0, y: 0.78, z: 0}
+--- !u!4 &2144716358
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2144716354}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 625583719}
+  - {fileID: 984588223}
+  - {fileID: 2144716358}
+  - {fileID: 1981571410}

--- a/Packages/com.utj.charactercontroller/Tests/Scenes/BrainUpdateTest.unity.meta
+++ b/Packages/com.utj.charactercontroller/Tests/Scenes/BrainUpdateTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c59f9e53f35548bb8c77d92ca15d220
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.utj.charactercontroller/Tests/Scripts/BrainUpdateTest.cs
+++ b/Packages/com.utj.charactercontroller/Tests/Scripts/BrainUpdateTest.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.TinyCharacterController.Brain;
+using Unity.TinyCharacterController.Core;
+using Unity.TinyCharacterController.Interfaces.Core;
+using UnityEngine;
+using UnityEngine.Serialization;
+using UnityEngine.TestTools;
+using UnityEngine.TestTools.Utils;
+
+namespace Unity.TinyCharacterController.Test
+{
+    public class BrainUpdateTest : SceneTestBase
+    {
+
+        [UnityTest]
+        public IEnumerator CharacterBrain時のDeltaTimeの更新()
+        {
+            var obj = GetObjectAndComponentInRoot<CharacterBrain>("CharacterBrain");
+            var mock = obj.gameObject.AddComponent<MockCheck>();
+            obj.gameObject.SetActive(true);
+
+            yield return new WaitForSeconds(1);
+
+            var delta = Mathf.Abs(mock.TimeAmount - 1);
+            
+            Assert.That(mock.DeltaTime, Is.EqualTo(Time.deltaTime).Using(FloatEqualityComparer.Instance));
+            Assert.That(delta, Is.LessThanOrEqualTo(Time.deltaTime));
+            Debug.Log(mock.DeltaTime);
+        }
+        
+        [UnityTest]
+        public IEnumerator RigidBodyBrain時のDeltaTimeの更新()
+        {
+            var obj = GetObjectAndComponentInRoot<RigidbodyBrain>("RigidbodyBrain");
+            var mock = obj.gameObject.AddComponent<MockCheck>();
+            obj.gameObject.SetActive(true);
+
+            yield return new WaitForSeconds(1);
+
+            var delta = Mathf.Abs(mock.TimeAmount - 1);
+            
+            Assert.That(mock.DeltaTime, Is.EqualTo(Time.fixedDeltaTime).Using(FloatEqualityComparer.Instance));
+            Assert.That(delta, Is.LessThanOrEqualTo(Time.fixedDeltaTime));
+            Debug.Log(mock.DeltaTime);
+        }
+
+        protected override string ScenePath =>
+            "Packages/com.unity.tiny.character.controller/Tests/Scenes/BrainUpdateTest.unity";
+        
+        [AddComponentMenu("")]
+        internal class MockCheck : MonoBehaviour, IEarlyUpdateComponent
+        {
+            public float TimeAmount;
+            public float DeltaTime;
+        
+            void IEarlyUpdateComponent.OnUpdate(float deltaTime)
+            {
+                TimeAmount += deltaTime;
+                DeltaTime = deltaTime;
+            }
+
+            int IEarlyUpdateComponent.Order => 0;
+        }
+
+    }
+}

--- a/Packages/com.utj.charactercontroller/Tests/Scripts/BrainUpdateTest.cs.meta
+++ b/Packages/com.utj.charactercontroller/Tests/Scripts/BrainUpdateTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9795768892179422f818eb8955c312cb


### PR DESCRIPTION
EarlyUpdateBrain and BrainBase require an appropriate deltaTime during updates. However, Time.deltaTime automatically provides the correct deltaTime based on the timing of Update/FixedUpdate, eliminating the need to specify deltaTime for each Brain.