### PR TITLE
改行コードが正常に変換できず、シナリオのインポート処理が正常に動作しない問題の修正

### DIFF
--- a/Packages/com.utj.scenarioimporter/Editor/ScenarioToDialogueConverter.cs
+++ b/Packages/com.utj.scenarioimporter/Editor/ScenarioToDialogueConverter.cs
@@ -38,9 +38,11 @@ namespace Unity.ScenarioImporter
         /// <returns>Normalized text data with consistent newline characters.</returns>
         private static string NormalizeNewLines(string textData)
         {
-            textData = textData.Replace("\r\n", Environment.NewLine);
-            textData = textData.Replace("\r", Environment.NewLine);
-            textData = textData.Replace("\n", Environment.NewLine); // Probably unnecessary
+            // First replace \r\n (Windows) with \n (Unix), and then \r (Mac) with \n
+            textData = textData.Replace("\r\n", "\n");
+            textData = textData.Replace("\r", "\n");
+            // Now replace all \n (Unix) with Environment.NewLine (Windows if on Windows)
+            textData = textData.Replace("\n", Environment.NewLine);
             return textData;
         }
 


### PR DESCRIPTION
Windowsで改行が認識されていない問題
ノーマライズで変換する先を `Environment.NewLine` から "\n" に変更